### PR TITLE
HPDD Auto 문제 관리 구축 공지

### DIFF
--- a/update_daily_algorithm.js
+++ b/update_daily_algorithm.js
@@ -6,9 +6,9 @@ dotenv.config();
 
 const GIT_TOKEN = process.env.GIT_TOKEN;
 const SOLVED_AC_BASE_URL = 'https://solved.ac/api/v3/problem/show';
-const SOURCE_OWNER = 'Hwarang-Oh';
+const SOURCE_OWNER = 'tony9402';
 const SOURCE_REPO = 'baekjoon';
-const SOURCE_PATH = 'main/picked.md';
+const SOURCE_PATH = 'picked.md';
 const TARGET_ORG = 'Hwarang2Platinum';
 const TARGET_REPO = 'algorithm';
 

--- a/update_daily_algorithm.js
+++ b/update_daily_algorithm.js
@@ -59,7 +59,7 @@ const fetchPickedTodayAlgorithm = async () => {
 
 const extractProblemId = (pickedProblems) => {
   const regex = /\[([0-9]+)\]\(https:\/\/www\.acmicpc\.net\/problem\/\1\)/g;
-  const ids = [...markdown.matchAll(regex)].map((match) => match[1]);
+  const ids = [...pickedProblems.matchAll(regex)].map((match) => match[1]);
   return ids;
 };
 
@@ -138,6 +138,17 @@ const createIssue = async (problemId, problemTitle, problemLevel, problemType) =
     title: issueTitle,
     body: issueBody,
     labels: issueLabels,
+    assignees: [
+      'kkho9654',
+      'wintiger98',
+      'dino9881',
+      'bladerunner3201',
+      'InbumS',
+      'Hwarang-Oh',
+      'chanmin97',
+      'Aiden-Jung',
+      'seungki-cho',
+    ],
   });
   console.log(`Issue created: ${data.data.html_url}`);
 };


### PR DESCRIPTION
### 주요 변경 사항
1. **백준 오늘의 문제 기반 Issue 자동 생성**
   - GitHub Actions Workflow를 활용하여 백준의 오늘의 문제를 기반으로 Issue가 자동 생성되도록 설정했습니다.
   - Issue 제목, Label, Assignee 등이 자동으로 설정되도록 구현했습니다.

2. **Label 및 Assignee 자동 설정**
   - 난이도에 따라 Label(Basic, Problem, Challenge 등)이 자동으로 설정됩니다.
   - 특정 멤버들이 Assignee로 지정되도록 설정.

### 가이드
- 반드시 모든 문제를 풀 필요는 없습니다.
- **1주일에 3~4개** 정도 풀고, **일요일 자정 전까지 PR**을 남겨주세요!

### 확정 추가
- HPDD Project 대시보드 정리

### 문제 상황
- 백준 -> 이 양반이 그냥 11월 26일 이후로 문제를 Update를 안하고 있음..위기위기!!

### 추가 예정
- Milestone 기반 Issue 관리. => 자동 Issue 종료 Logic에 추가 예정
- Issue가 종료되면 ( 일요일 자정 ) => 문제 Type 공개 예정
- Solved AC의 API를 통해서, 너무 풀었던 문제들이 PR되면 막을 기능도 고민하고 있습니다
- 가져오는 오늘의 문제를 DB에 저장하거나, 자동 분류를 통해 아카이빙할 계획도 있습니다. 

리뷰 부탁드립니다. 😊